### PR TITLE
feat: support customized redis topic

### DIFF
--- a/src/main/java/org/casbin/spring/boot/autoconfigure/CasbinRedisWatcherAutoConfiguration.java
+++ b/src/main/java/org/casbin/spring/boot/autoconfigure/CasbinRedisWatcherAutoConfiguration.java
@@ -37,14 +37,13 @@ import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
 public class CasbinRedisWatcherAutoConfiguration {
 
     private final static Logger logger = LoggerFactory.getLogger(CasbinRedisWatcherAutoConfiguration.class);
-    public final static String CASBIN_POLICY_TOPIC = "CASBIN_POLICY_TOPIC";
 
     @Bean
     @ConditionalOnBean(RedisTemplate.class)
     @ConditionalOnMissingBean
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-    public Watcher redisWatcher(StringRedisTemplate stringRedisTemplate, Enforcer enforcer) {
-        RedisWatcher watcher = new RedisWatcher(stringRedisTemplate);
+    public Watcher redisWatcher(StringRedisTemplate stringRedisTemplate, Enforcer enforcer, CasbinProperties casbinProperties) {
+        RedisWatcher watcher = new RedisWatcher(stringRedisTemplate, casbinProperties.getPolicyTopic());
         enforcer.setWatcher(watcher);
         logger.info("Casbin set watcher: {}", watcher.getClass().getName());
         return watcher;
@@ -71,12 +70,13 @@ public class CasbinRedisWatcherAutoConfiguration {
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     public RedisMessageListenerContainer redisMessageListenerContainer(
             RedisConnectionFactory connectionFactory,
-            MessageListenerAdapter listenerAdapter
+            MessageListenerAdapter listenerAdapter,
+            CasbinProperties casbinProperties
     ) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();
         container.setConnectionFactory(connectionFactory);
         // subscribe to the CASBIN_POLICY_TOPIC channel
-        container.addMessageListener(listenerAdapter, new ChannelTopic(CASBIN_POLICY_TOPIC));
+        container.addMessageListener(listenerAdapter, new ChannelTopic(casbinProperties.getPolicyTopic()));
         return container;
     }
 }

--- a/src/main/java/org/casbin/spring/boot/autoconfigure/properties/CasbinProperties.java
+++ b/src/main/java/org/casbin/spring/boot/autoconfigure/properties/CasbinProperties.java
@@ -46,6 +46,10 @@ public class CasbinProperties {
      */
     private CasbinWatcherType watcherType = CasbinWatcherType.REDIS;
     /**
+     * Redis topic for Watcher
+     */
+    private String policyTopic = "CASBIN_POLICY_TOPIC";
+    /**
      * Data table initialization strategy
      */
     private CasbinDataSourceInitializationMode initializeSchema = CasbinDataSourceInitializationMode.CREATE;
@@ -169,5 +173,13 @@ public class CasbinProperties {
 	public void setTableName(String tableName) {
 		this.tableName = tableName;
 	}
+
+    public String getPolicyTopic() {
+        return policyTopic;
+    }
+
+    public void setPolicyTopic(String policyTopic) {
+        this.policyTopic = policyTopic;
+    }
 }
 

--- a/src/main/java/org/casbin/watcher/RedisWatcher.java
+++ b/src/main/java/org/casbin/watcher/RedisWatcher.java
@@ -1,7 +1,6 @@
 package org.casbin.watcher;
 
 import org.casbin.jcasbin.persist.Watcher;
-import org.casbin.spring.boot.autoconfigure.CasbinRedisWatcherAutoConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -17,14 +16,17 @@ import java.util.UUID;
  * @date 2019-4-06 1:58
  */
 public class RedisWatcher implements Watcher {
+
     private Runnable updateCallback;
+    private final String policyTopic;
     private final StringRedisTemplate stringRedisTemplate;
     private final static String REDIS_WATCHER_UUID = UUID.randomUUID().toString();
     private final static Logger logger = LoggerFactory.getLogger(RedisWatcher.class);
 
-    public RedisWatcher(StringRedisTemplate stringRedisTemplate) {
+    public RedisWatcher(StringRedisTemplate stringRedisTemplate, String policyTopic) {
+        this.policyTopic = policyTopic;
         this.stringRedisTemplate = stringRedisTemplate;
-        logger.info("Current casbin redis watcher uuid: {}", REDIS_WATCHER_UUID);
+        logger.info("Current casbin redis watcher uuid: {}, subscribe topic: {}", REDIS_WATCHER_UUID, this.policyTopic);
     }
 
     @Override
@@ -35,7 +37,7 @@ public class RedisWatcher implements Watcher {
     @Override
     public void update() {
         stringRedisTemplate.convertAndSend(
-                CasbinRedisWatcherAutoConfiguration.CASBIN_POLICY_TOPIC,
+                this.policyTopic,
                 "Casbin policy has a new version from redis watcher: " + REDIS_WATCHER_UUID
         );
     }

--- a/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -83,6 +83,13 @@
       "defaultValue": "redis"
     },
     {
+      "name": "casbin.policyTopic",
+      "type": "java.lang.String",
+      "description": "Redis topic for Watcher",
+      "sourceType": "org.casbin.spring.boot.autoconfigure.properties.CasbinProperties",
+      "defaultValue": "CASBIN_POLICY_TOPIC"
+    },
+    {
       "name": "casbin.exception.removePolicyFailed",
       "type": "java.lang.Boolean",
       "description": "Throws an exception when the delete policy fails",

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -27,6 +27,9 @@ casbin:
   # and only Redis is supported for the time being
   # After opening Watcher, you need to manually add spring-boot-starter-data-redis dependency
   watcherType: redis
+  # Add your Customer Topic here or it will go with 'CASBIN_POLICY_TOPIC' by default
+  policyTopic: YOUR_CUSTOMER_TOPIC
+
 spring:
   # Although the data source is configured here, the custom data source is switched to H2 when the unit test is tested.
   datasource:


### PR DESCRIPTION
Fix: https://github.com/jcasbin/casbin-spring-boot-starter/issues/54

## You can now make the watcher subscribe customized redis topic
> fix issue #54 

Edit your `application.yml` as shown bellow
~~~yml
casbin:
  # Add your Customer Topic here or it will go with 'CASBIN_POLICY_TOPIC' by default
  policyTopic: YOUR_CUSTOMER_TOPIC
~~~