### PR TITLE
fix: use mavenCentral as default repository instead of aliyun

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ jar.enabled = true
 
 repositories {
     mavenLocal()
-    maven { url "https://maven.aliyun.com/repository/public/" }
     mavenCentral()
 }
 


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>

Fix: https://github.com/jcasbin/casbin-spring-boot-starter/issues/59 