### PR TITLE
fix: org.h2.jdbc.JdbcSQLSyntaxErrorException after H2 version upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ configurations {
 
 dependencies {
     compile 'org.casbin:jcasbin:1.21.0'
-    compile 'com.h2database:h2'
+    compile 'com.h2database:h2:2.1.210'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
     compileOnly 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/org/casbin/adapter/JdbcAdapter.java
+++ b/src/main/java/org/casbin/adapter/JdbcAdapter.java
@@ -36,7 +36,7 @@ public class JdbcAdapter implements FilteredAdapter {
 	private String tableName;
 
     private static final String INIT_TABLE_SQL = "CREATE TABLE IF NOT EXISTS casbin_rule (" +
-            "    id int(11) NOT NULL AUTO_INCREMENT PRIMARY KEY, "+
+            "    id    int          NOT NULL AUTO_INCREMENT PRIMARY KEY, "+
             "    ptype varchar(255) NOT NULL," +
             "    v0    varchar(255) DEFAULT NULL," +
             "    v1    varchar(255) DEFAULT NULL," +


### PR DESCRIPTION
Signed-off-by: Yixiang Zhao <seriouszyx@foxmail.com>

Fix: https://github.com/jcasbin/casbin-spring-boot-starter/issues/61

`INT(11)` is allowed only in MySQL and MariaDB compatibility modes, but the specified precision is ignored by H2. This definition is rejected in all other compatibility modes in H2 2.0. 

https://stackoverflow.com/questions/70695039/org-h2-jdbc-jdbcsqlsyntaxerrorexception-after-h2-version-upgrade/70696184