### PR TITLE
fix: update the way to get the driver

### DIFF
--- a/src/main/java/org/casbin/spring/boot/autoconfigure/CasbinAutoConfiguration.java
+++ b/src/main/java/org/casbin/spring/boot/autoconfigure/CasbinAutoConfiguration.java
@@ -89,7 +89,7 @@ public class CasbinAutoConfiguration {
         boolean autoCreateTable = initializeSchema == CasbinDataSourceInitializationMode.CREATE;
         String tableName = properties.getTableName();
         logger.info("Casbin current use database product: {}", databaseName);
-        return new JDBCAdapter(dataSourceProperties.getDriverClassName(), dataSourceProperties.getUrl(),
+        return new JDBCAdapter(dataSourceProperties.determineDriverClassName(), dataSourceProperties.getUrl(),
                 dataSourceProperties.getUsername(), dataSourceProperties.getPassword(),
                 exceptionProperties.isRemovePolicyFailed(), tableName, autoCreateTable);
 


### PR DESCRIPTION
…ies.determineDriverClassName()

Because if the user does not configure the driver class name, a null pointer will be thrown