### PR TITLE
fix: jcasbin was not included when published, with api it's letting G…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
     id 'java'
+    id 'java-library'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.springframework.boot' version '2.7.4' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
@@ -38,7 +39,7 @@ dependencyManagement {
 }
 
 dependencies {
-    compileOnly 'org.casbin:jcasbin:1.30.1'
+    api "org.casbin:jcasbin:1.30.1"
     compileOnly 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.h2database:h2:2.1.214'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'


### PR DESCRIPTION
…radle know that the module wants to transitively export that dependency to other modules, so that it's available to them at both runtime and compile time. This configuration behaves just like compile (which is now deprecated)

Fix: https://github.com/jcasbin/casbin-spring-boot-starter/issues/75